### PR TITLE
throw errors after logging exceptions

### DIFF
--- a/eitri-shopping-vtex-shared/eitri-app.conf.js
+++ b/eitri-shopping-vtex-shared/eitri-app.conf.js
@@ -4,7 +4,7 @@ module.exports = {
 	'slug': 'eitri-shopping-vtex-shared',
 	'eitri-luminus': '1.78.2',
 	'eitri-bifrost': '3.10.0',
-	'version': '1.2.2',
+	'version': '1.2.3',
 	'messageVersion': 'Lancamento de erro',
 	'public-key': '0b837c87-a494-4521-9b0f-5ac49db5af9c',
 	'applicationId': '99c18c0a-4112-4937-b27c-802d03f4e9e9',

--- a/eitri-shopping-vtex-shared/jsconfig.json
+++ b/eitri-shopping-vtex-shared/jsconfig.json
@@ -2,17 +2,17 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "eitri-bifrost": [
-        "/var/folders/tp/mgwmq3416rx3zs9gwl3w4lcc0000gn/T/eitri-shopping-vtex-shared/node_modules/eitri-bifrost"
-      ],
-      "react/jsx-runtime": [
-        "/var/folders/tp/mgwmq3416rx3zs9gwl3w4lcc0000gn/T/eitri-shopping-vtex-shared/node_modules/react/jsx-dev-runtime"
-      ],
       "react": [
         "/var/folders/tp/mgwmq3416rx3zs9gwl3w4lcc0000gn/T/eitri-shopping-vtex-shared/node_modules/react"
       ],
       "eitri-luminus": [
         "/var/folders/tp/mgwmq3416rx3zs9gwl3w4lcc0000gn/T/eitri-shopping-vtex-shared/node_modules/eitri-app-components"
+      ],
+      "react/jsx-runtime": [
+        "/var/folders/tp/mgwmq3416rx3zs9gwl3w4lcc0000gn/T/eitri-shopping-vtex-shared/node_modules/react/jsx-dev-runtime"
+      ],
+      "eitri-bifrost": [
+        "/var/folders/tp/mgwmq3416rx3zs9gwl3w4lcc0000gn/T/eitri-shopping-vtex-shared/node_modules/eitri-bifrost"
       ]
     },
     "target": "ESNext",

--- a/eitri-shopping-vtex-shared/src/services/vtex/search/vtexSearchGraphql.ts
+++ b/eitri-shopping-vtex-shared/src/services/vtex/search/vtexSearchGraphql.ts
@@ -64,8 +64,16 @@ export default class VtexSearchGraphql {
 		const { host } = Vtex.configs
 		const query = this.toGraphQLArgs(input)
 
+		const _query = query
+			.replace('"id"', 'id')
+			.replace('"slug"', 'slug')
+			.replace('"reference"', 'reference')
+			.replace('"ean"', 'ean')
+			.replace('"sku"', 'sku')
+			.replace('"buy"', 'buy')
+
 		const body = {
-			query: `{ product(${query}) @context(provider: "vtex.search-graphql")  ${returnProperties || productReturn}  }`
+			query: `{ product(${_query}) @context(provider: "vtex.search-graphql")  ${returnProperties || productReturn}  }`
 		}
 
 		const response = await VtexCaller.post(`api/io/_v/private/graphql/v1`, body, null, host)

--- a/eitri-shopping-vtex-shared/src/views/GraphqlSearchMethods.jsx
+++ b/eitri-shopping-vtex-shared/src/views/GraphqlSearchMethods.jsx
@@ -37,7 +37,7 @@ export default function GraphqlSearchMethods() {
 	const getProduct = async () => {
 		try {
 			const res = await Vtex.searchGraphql.product({
-				slug: 'camisa-polo-plus-size-masculina-algodao-peruano-bege-21322000499028'
+				identifier: { field: 'id', value: '2023347' }
 			})
 			console.log(res)
 		} catch (e) {


### PR DESCRIPTION
- Updated `vtexCheckoutService` and `vtexPaymentService` to consistently throw errors after logging.
- Changed `throw Error(e)` to `throw e` for improved error handling.
- Incremented version to 1.2.3.