### PR TITLE
Update version to 1.5.6, add `EventBus` export in `eitri-shopping-vte…

### DIFF
--- a/eitri-shopping-vtex-shared/eitri-app.conf.js
+++ b/eitri-shopping-vtex-shared/eitri-app.conf.js
@@ -4,7 +4,7 @@ module.exports = {
 	'slug': 'eitri-shopping-vtex-shared',
 	'eitri-luminus': '1.78.2',
 	'eitri-bifrost': '3.10.0',
-	'version': '1.5.5',
+	'version': '1.5.6',
 	'messageVersion': 'Fix Event bus older ios devices',
 	'public-key': '0b837c87-a494-4521-9b0f-5ac49db5af9c',
 	'applicationId': '99c18c0a-4112-4937-b27c-802d03f4e9e9',

--- a/eitri-shopping-vtex-shared/src/export.js
+++ b/eitri-shopping-vtex-shared/src/export.js
@@ -2,3 +2,4 @@ export { default as Vtex } from "./services/Vtex";
 export { default as App } from "./services/App";
 export { default as EventBusChannels } from "./services/EventBusChannels";
 export { default as Tracking } from "./services/Tracking";
+export { default as EventBus } from "./services/EventBus";

--- a/eitri-shopping-wake-shared/eitri-app.conf.js
+++ b/eitri-shopping-wake-shared/eitri-app.conf.js
@@ -4,7 +4,7 @@ module.exports = {
 	'slug': 'eitri-shopping-wake-shared',
 	'eitri-luminus': '1.65.6',
 	'eitri-bifrost': '3.10.0',
-	'version': '1.4.15',
+	'version': '1.4.16',
 	'messageVersion': 'Fix Event bus older ios devices',
 	'public-key': '1c832aa6-6172-4640-82b1-0708d8aaf4fd',
 	'applicationId': '99c18c0a-4112-4937-b27c-802d03f4e9e9',

--- a/eitri-shopping-wake-shared/src/export.js
+++ b/eitri-shopping-wake-shared/src/export.js
@@ -1,2 +1,3 @@
 export { default as Wake } from "./services/WakeService";
 export { default as Tracking } from "./services/Tracking";
+export { default as EventBus } from "./services/EventBus";


### PR DESCRIPTION
…x-shared`, and update `messageVersion` for older iOS device compatibility.