### PR TITLE
Update version to 1.6.3, simplify `VtexGooglePayServices` by reducing…

### DIFF
--- a/eitri-shopping-vtex-shared/eitri-app.conf.js
+++ b/eitri-shopping-vtex-shared/eitri-app.conf.js
@@ -4,7 +4,7 @@ module.exports = {
 	'slug': 'eitri-shopping-vtex-shared',
 	'eitri-luminus': '1.78.2',
 	'eitri-bifrost': '4.2.0',
-	'version': '1.6.2',
+	'version': '1.6.3',
 	'messageVersion': 'Adiciona Google Pay Payment data',
 	'public-key': '0b837c87-a494-4521-9b0f-5ac49db5af9c',
 	'applicationId': '99c18c0a-4112-4937-b27c-802d03f4e9e9',

--- a/eitri-shopping-vtex-shared/src/services/vtex/googlePay/vtexGooglePayServices.ts
+++ b/eitri-shopping-vtex-shared/src/services/vtex/googlePay/vtexGooglePayServices.ts
@@ -80,22 +80,7 @@ export class VtexGooglePayServices {
 		}
 
 		const paymentsClient = await Eitri.googlePay.init(env)
-		const paymentData = await paymentsClient.loadPaymentData(paymentDataRequest)
-
-		const token = paymentData?.paymentMethodData?.tokenizationData.token
-		const billingAddress = paymentData?.paymentMethodData?.info?.billingAddress
-
-		return  {
-			walletId: 'googlePay',
-			paymentData: {
-				assuranceDetails: {
-					cardHolderAuthenticated: false,
-					accountVerified: true
-				},
-				billingAddress: billingAddress,
-				token: token
-			}
-		}
+		return await paymentsClient.loadPaymentData(paymentDataRequest)
 
 	}
 

--- a/eitri-shopping-vtex-shared/src/views/CheckoutMethods.jsx
+++ b/eitri-shopping-vtex-shared/src/views/CheckoutMethods.jsx
@@ -252,7 +252,7 @@ export default function CheckoutMethods() {
 
 			console.log("Payment Data:", payload);
 
-			// const result = await Vtex.checkout.payV2(cart, payload)
+			const result = await Vtex.checkout.payV2(cart, payload)
 
 
 			console.log("Payment successful:", paymentData.paymentMethodData);

--- a/eitri-shopping-vtex-shared/src/views/Home.jsx
+++ b/eitri-shopping-vtex-shared/src/views/Home.jsx
@@ -25,7 +25,7 @@ export default function Home() {
 		// 	utm_campaign: 'app2'
 		// })
 		// console.log('[SHARED] End ===> ', new Date().getTime() - a)
-		// await Vtex.cart.setOrderFormId('03d3898939334c8c91d9386af0c22d38')
+		// await Vtex.cart.setOrderFormId('c9bcc5e093f9457382c5079efd04f3c7')
 		await Vtex.cart.getCurrentOrCreateCart()
 	}
 


### PR DESCRIPTION
… payment data processing logic, uncomment `payV2` in `CheckoutMethods`, and update `messageVersion` in configuration.